### PR TITLE
Testing Infra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build: init
 
 .PHONY: test
 test: build
-	make -C $(PWD)/$(BUILD_DIR) -j $(JOBS) test
+	make -C $(PWD)/$(BUILD_DIR) -j $(JOBS) test CTEST_OUTPUT_ON_FAILURE=1
 
 .PHONY: clean
 .SILENT: clean

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,10 @@
+
+function(besm666_simple_test SOURCE_NAME)
+    get_filename_component(TARGET_NAME ${SOURCE_NAME} NAME_WE)
+    add_executable(${TARGET_NAME})
+    target_sources(${TARGET_NAME} PRIVATE ${SOURCE_NAME})
+    target_link_libraries(${TARGET_NAME} PRIVATE gtest_main gtest)
+    add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})
+endfunction(besm666_simple_test)
+
+besm666_simple_test(./dummy_test.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,12 @@
 
+add_library(besm666_testif INTERFACE)
+target_link_libraries(besm666_testif INTERFACE gmock_main gmock gtest)
+
 function(besm666_simple_test SOURCE_NAME)
     get_filename_component(TARGET_NAME ${SOURCE_NAME} NAME_WE)
     add_executable(${TARGET_NAME})
     target_sources(${TARGET_NAME} PRIVATE ${SOURCE_NAME})
-    target_link_libraries(${TARGET_NAME} PRIVATE gtest_main gtest)
+    target_link_libraries(${TARGET_NAME} PRIVATE besm666_testif)
     add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})
 endfunction(besm666_simple_test)
 

--- a/test/dummy_test.cpp
+++ b/test/dummy_test.cpp
@@ -8,6 +8,4 @@ TEST(dummy, dummy_test_fail) {
 }
 */
 
-TEST(dummy, dummy_test_success) {
-    EXPECT_TRUE(true);
-}
+TEST(dummy, dummy_test_success) { EXPECT_TRUE(true); }

--- a/test/dummy_test.cpp
+++ b/test/dummy_test.cpp
@@ -1,0 +1,13 @@
+
+#include <gtest/gtest.h>
+
+// Try it youself, CI won't allow me to merge this
+/*
+TEST(dummy, dummy_test_fail) {
+    EXPECT_TRUE(false);
+}
+*/
+
+TEST(dummy, dummy_test_success) {
+    EXPECT_TRUE(true);
+}


### PR DESCRIPTION
Adds
- cmake method `besm666_simple_test` for convenient single-file test creation
- example test `dummy_test_success` & `dummy_test_fail`
- verbose output from `gtest` on test failure 