### PR TITLE
Fix quotation in clang-format tool

### DIFF
--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -2,7 +2,7 @@ if [ ! -d "$1" ]; then
     exit 0
 fi
 
-find $1 -name "*.cpp" -or -name "*.hpp" \
-         -name "*.hxx" -or -name "*.cxx" \
-         -name "*.h"  | \
+find $1 -name '*.cpp' -or -name '*.hpp' \
+         -name '*.hxx' -or -name '*.cxx' \
+         -name '*.h'  | \
     xargs -n 1 clang-format -i


### PR DESCRIPTION
Fixes quotation in clang-format bash script to make working source file searching `find` call