### PR TITLE
Add plugins support & debug-tracer plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ if(DEFINED BESM666__SIMULATOR_BUILD)
     include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)
 
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
     find_package(Python3 REQUIRED)
     find_package(Git REQUIRED)
 
@@ -86,6 +88,7 @@ if(DEFINED BESM666__SIMULATOR_BUILD)
     add_subdirectory(src)
     add_subdirectory(standalone)
     add_subdirectory(third_party)
+    add_subdirectory(plugins)
 
     enable_testing()
     if (DEFINED BESM666_TEST_WITH_VALGRIND)

--- a/include/besm-666/sim/config.hpp
+++ b/include/besm-666/sim/config.hpp
@@ -3,13 +3,16 @@
 #include <cstddef>
 #include <filesystem>
 #include <functional>
+#include <vector>
 #include <stdexcept>
+#include <string>
 
 namespace besm::sim {
 
 struct ConfigData {
     // Input files
     std::filesystem::path executablePath;
+    std::vector<std::string> plugins;
 };
 
 class InvalidConfiguration : public std::runtime_error {
@@ -22,6 +25,7 @@ public:
 class Config {
 public:
     std::filesystem::path executablePath() const;
+    std::vector<std::string> const& plugins() const;
 
 private:
     friend class ConfigBuilder;
@@ -35,6 +39,7 @@ public:
     ConfigBuilder() = default;
 
     void setExecutablePath(std::filesystem::path executablePath);
+    void addPlugin(std::filesystem::path path);
 
     Config build();
 

--- a/include/besm-666/sim/hooks.hpp
+++ b/include/besm-666/sim/hooks.hpp
@@ -9,7 +9,12 @@ namespace besm::sim {
 
 class HookManager {
 public:
-    enum Event { INSTRUCTION_FETCH, INSTRUCTION_DECODE, INSTRUCTION_EXECUTE };
+    enum Event { 
+        SIMULATION_STARTED,
+        SIMULATION_FINISHED,
+        INSTRUCTION_FETCH, 
+        INSTRUCTION_DECODE, 
+        INSTRUCTION_EXECUTE };
 
     using SPtr = std::shared_ptr<HookManager>;
     using Callback = void (*)(sim::Hart const &hart, void const *extraArg);

--- a/include/besm-666/sim/machine.hpp
+++ b/include/besm-666/sim/machine.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <vector>
+
+#include "besm-666/util/non-copyable.hpp"
 #include "besm-666/sim/config.hpp"
 #include "besm-666/sim/hart.hpp"
 #include "besm-666/sim/hooks.hpp"
-#include "besm-666/util/non-copyable.hpp"
+#include "besm-666/sim/plugin.hpp"
 
 namespace besm::sim {
 
@@ -19,7 +22,10 @@ public:
     sim::HookManager::SPtr getHookManager() { return hookManager_; }
 
 private:
+    void loadPlugins(sim::Config const& config);
+
     HookManager::SPtr hookManager_;
+    std::vector<Plugin> plugins_;
     mem::PhysMem::SPtr pMem_;
     sim::Hart::SPtr hart_;
 };

--- a/include/besm-666/sim/plugin.hpp
+++ b/include/besm-666/sim/plugin.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+#include <ostream>
+
+#include "besm-666/util/non-copyable.hpp"
+#include "besm-666/util/dynamic-library.hpp"
+#include "besm-666/sim/hooks.hpp"
+
+namespace besm::sim {
+
+class Plugin : public INonCopyable {
+public:
+    Plugin(std::string const& path);
+    Plugin(Plugin&& other);
+
+    Plugin const& operator=(Plugin&& other);
+
+    ~Plugin() = default;
+
+    void init(sim::HookManager::SPtr hookManager, std::string const& commandLine,
+        std::ostream& defaulLogStream);
+
+private:
+    using InitFunction = void(*)(sim::HookManager::SPtr, std::string const&,
+        std::ostream&);
+
+    util::DynamicLibrary pluginLibrary_;
+};
+
+}

--- a/include/besm-666/util/dynamic-library.hpp
+++ b/include/besm-666/util/dynamic-library.hpp
@@ -1,0 +1,48 @@
+#include <string>
+#include <stdexcept>
+#include <filesystem>
+
+#include "besm-666/util/non-copyable.hpp"
+
+namespace besm::util {
+
+class DynamicLibraryError : public std::runtime_error {
+public:
+    DynamicLibraryError(std::string const& message) :
+        runtime_error(message) {}
+    DynamicLibraryError(char const* message) :
+        runtime_error(message) {}
+};
+
+class DynamicLibrarySymbolNotFound : public std::runtime_error {
+public:
+    DynamicLibrarySymbolNotFound(std::string const& message) :
+        runtime_error(message) {}
+    DynamicLibrarySymbolNotFound(char const* message) :
+        runtime_error(message) {}
+};
+
+class DynamicLibrary : public INonCopyable {
+public:
+    explicit DynamicLibrary(std::filesystem::path const& path);
+    DynamicLibrary(DynamicLibrary&& other);
+    ~DynamicLibrary();
+
+    DynamicLibrary const& operator=(DynamicLibrary&& other);
+
+    void* getSymbol(std::string const& symbol);
+
+    template<typename FunctionType>
+    FunctionType getFunction(std::string const& symbol);
+
+private:
+    void* handle_;
+};
+
+template<typename FunctionType>
+inline FunctionType DynamicLibrary::getFunction(std::string const& symbol) {
+    return reinterpret_cast<FunctionType>(this->getSymbol(symbol));
+}
+
+    
+}

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(debug_tracer)

--- a/plugins/debug_tracer/CMakeLists.txt
+++ b/plugins/debug_tracer/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(BESM-666-DebugTracer
+    LANGUAGES CXX
+    VERSION 1.0.0
+    DESCRIPTION "Plugin used to debug the simulator"
+)
+
+add_library(besm666_debug_tracer SHARED)
+target_sources(besm666_debug_tracer PRIVATE
+    ./debug-tracer.cpp
+)
+target_link_libraries(besm666_debug_tracer PRIVATE
+    besm666_include
+    capstone::capstone
+    CLI11::CLI11
+)

--- a/plugins/debug_tracer/debug-tracer.cpp
+++ b/plugins/debug_tracer/debug-tracer.cpp
@@ -1,0 +1,96 @@
+#include <iostream>
+#include "CLI/CLI.hpp"
+#include "besm-666/exec/gprf.hpp"
+#include "besm-666/instruction.hpp"
+#include "besm-666/riscv-types.hpp"
+#include "capstone/capstone.h"
+
+#include "besm-666/sim/hooks.hpp"
+#include "besm-666/sim/hart.hpp"
+
+namespace {
+
+std::ofstream logFile;
+std::ostream* pLogStream = nullptr;
+
+
+csh CapstoneHandler;
+
+void InstructionFetchHandler(besm::sim::Hart const& hart, void const* pBytecode) {
+    besm::RV64UWord bytecode = *reinterpret_cast<besm::RV64UWord const*>(pBytecode);
+    besm::RV64UDWord pc = hart.getState().read(besm::exec::GPRF::PC);
+
+    *pLogStream << "[DebugTracer] Fetched bytecode " << std::hex << bytecode <<
+        std::dec << " at pc = " << pc << ", disassembly:\n\t";
+
+    cs_insn* instruction;
+    size_t count = cs_disasm(CapstoneHandler, reinterpret_cast<uint8_t const*>(pBytecode),
+        4, pc, 0, &instruction);
+
+    if(count > 0) {
+        *pLogStream << instruction->mnemonic << " " << instruction->op_str << std::endl;
+    } else {
+        *pLogStream << "[unable to disasm]" << std::endl;
+    }
+
+    cs_free(instruction, count);
+}
+
+void InstructionDecodeHandler(besm::sim::Hart const& hart, void const* pInstr) {
+    // Too early to implement it
+}
+
+void InstructionExecHandler(besm::sim::Hart const& hart, void const*) {
+    *pLogStream << "[DebugTracer] Instruction executed. Force dumping machine state..." 
+        << std::endl;
+    besm::exec::GPRFStateDumper(*pLogStream).dump(hart.getState());
+}
+
+}
+
+extern "C" {
+
+void init(besm::sim::HookManager::SPtr hookManager, std::string const& commandLine,
+    std::ostream& defaultLogStream) {
+    pLogStream = &defaultLogStream;
+
+    *pLogStream << "[DebugTracer] DebugTracer plugin enabled, good luck in debugging!" 
+        << std::endl;
+
+    std::string logFilePath;
+
+    CLI::App app;
+    app.add_option("-l,--log-file", logFilePath, 
+        "Dump logs to file (dumped to clog by default)");
+
+    app.parse(commandLine, true);
+
+    if(!logFilePath.empty()) {
+        logFile.open(logFilePath);
+        if(!logFile.is_open()) {
+            *pLogStream << "[DebugTracer] Failed to open log file \'" <<
+                logFilePath << "\', using clog stream instead" << std::endl;
+        } else {
+            *pLogStream << "[DebugTracer] Log file was set up" << std::endl;
+            std::ref(*pLogStream) = logFile;
+        }
+    }
+
+    cs_err csErr = cs_open(CS_ARCH_RISCV, CS_MODE_RISCV64, &CapstoneHandler);
+    if(csErr != CS_ERR_OK) {
+        *pLogStream << "[DebugTracer] Unable to initialize capstone engine, " 
+            "disassembly will be unavailable" << std::endl;
+        *pLogStream << "[DebugTracer] The error occured in Capstone Engine is \'" <<
+            cs_strerror(csErr) << "\'" << std::endl;
+    }
+
+    hookManager->registerHook(besm::sim::HookManager::INSTRUCTION_FETCH,
+        InstructionFetchHandler);
+    hookManager->registerHook(besm::sim::HookManager::INSTRUCTION_DECODE,
+        InstructionDecodeHandler);
+    hookManager->registerHook(besm::sim::HookManager::INSTRUCTION_EXECUTE,
+        InstructionExecHandler);
+}
+
+}
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,9 @@ PUBLIC
     besm666_decoder
     besm666_sim
 )
+target_link_options(besm666_shared PRIVATE
+    "-Wl,-export-dynamic"
+)
 
 add_subdirectory(memory)
 add_subdirectory(util)

--- a/src/sim/CMakeLists.txt
+++ b/src/sim/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(besm666_sim PRIVATE
     ./hart.cpp
     ./machine.cpp
     ./hooks.cpp
+    ./plugin.cpp
 )
 target_link_libraries(besm666_sim PRIVATE
     besm666_include

--- a/src/sim/config.cpp
+++ b/src/sim/config.cpp
@@ -5,8 +5,16 @@ std::filesystem::path Config::executablePath() const {
     return data_.executablePath;
 }
 
+std::vector<std::string> const& Config::plugins() const {
+    return data_.plugins;
+}
+
 void ConfigBuilder::setExecutablePath(std::filesystem::path path) {
     data_.executablePath = path;
+}
+
+void ConfigBuilder::addPlugin(std::filesystem::path path) {
+    data_.plugins.push_back(path);
 }
 
 Config ConfigBuilder::build() {

--- a/src/sim/hart.cpp
+++ b/src/sim/hart.cpp
@@ -46,9 +46,11 @@ bool Hart::finished() const {
 }
 
 void Hart::run() {
+    hookManager_->triggerHooks(HookManager::SIMULATION_STARTED, *this, nullptr);
     while (!this->finished()) {
         this->runCycle();
     }
+    hookManager_->triggerHooks(HookManager::SIMULATION_FINISHED, *this, nullptr);
 }
 
 } // namespace besm::sim

--- a/src/sim/hooks.cpp
+++ b/src/sim/hooks.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <iostream>
 
 #include "besm-666/sim/hooks.hpp"
 

--- a/src/sim/machine.cpp
+++ b/src/sim/machine.cpp
@@ -9,10 +9,23 @@ Machine::Machine(sim::Config const &config) {
 
     hookManager_ = sim::HookManager::Create();
     hart_ = sim::Hart::Create(pMem_, hookManager_);
+
+    this->loadPlugins(config);
 }
 
 void Machine::run() { hart_->run(); }
 
 exec::GPRF const &Machine::getState() const { return hart_->getState(); }
+
+void Machine::loadPlugins(sim::Config const& config) {
+    for(auto const& pluginCmd : config.plugins()) {
+        std::filesystem::path pluginPath = pluginCmd.substr(0,
+            pluginCmd.find(" "));
+
+        Plugin plugin(pluginPath);
+        plugin.init(hookManager_, pluginCmd, std::clog);
+        plugins_.push_back(std::move(plugin));
+    }
+}
 
 } // namespace besm::sim

--- a/src/sim/plugin.cpp
+++ b/src/sim/plugin.cpp
@@ -1,0 +1,22 @@
+#include "besm-666/sim/plugin.hpp"
+
+namespace besm::sim {
+
+Plugin::Plugin(std::string const& path) :
+    pluginLibrary_(path) {}
+Plugin::Plugin(Plugin&& other) :
+    pluginLibrary_(std::move(other.pluginLibrary_)) {}
+
+Plugin const& Plugin::operator=(Plugin&& other) {
+    std::swap(pluginLibrary_, other.pluginLibrary_);
+    return *this;
+}
+
+void Plugin::init(sim::HookManager::SPtr hookManager, std::string const& commandLine,
+    std::ostream& defaultLogStream) {
+    pluginLibrary_.getFunction<InitFunction>("init")(hookManager, commandLine,
+        defaultLogStream);
+}
+
+
+}

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_library(besm666_util STATIC)
 target_sources(besm666_util PRIVATE
     ./elf-parser.cpp
+    ./dynamic-library.cpp
 )
 target_link_libraries(besm666_util
 PUBLIC

--- a/src/util/dynamic-library.cpp
+++ b/src/util/dynamic-library.cpp
@@ -1,0 +1,42 @@
+#include <dlfcn.h>
+
+#include "besm-666/util/dynamic-library.hpp"
+
+namespace besm::util {
+
+DynamicLibrary::DynamicLibrary(std::filesystem::path const& path) {
+    handle_ = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
+    if(handle_ == nullptr) {
+        char const* dl_error = dlerror();
+        throw DynamicLibraryError(dl_error);
+    }
+}
+DynamicLibrary::DynamicLibrary(DynamicLibrary&& other) {
+    handle_ = other.handle_;
+    other.handle_ = nullptr;
+}
+
+DynamicLibrary const& DynamicLibrary::operator=(DynamicLibrary&& other) {
+    std::swap(handle_, other.handle_);
+    return *this;
+}
+
+DynamicLibrary::~DynamicLibrary() {
+    if(handle_) {
+        dlclose(handle_);
+    }
+}
+
+void* DynamicLibrary::getSymbol(std::string const& symbol) {
+    if(handle_) {
+        void* symbolAddr = dlsym(handle_, symbol.c_str());
+        if(symbolAddr == nullptr) {
+            throw DynamicLibrarySymbolNotFound(symbol);
+        }
+        return symbolAddr;
+    } else {
+        return nullptr;
+    }
+}
+
+}

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -7,5 +7,7 @@ target_sources(besm666_standalone PRIVATE
 target_link_libraries(besm666_standalone PRIVATE
     besm666_shared
     CLI11::CLI11
-    capstone::capstone
+)
+target_link_options(besm666_standalone PRIVATE
+    "-Wl,-export-dynamic"
 )

--- a/standalone/main.cpp
+++ b/standalone/main.cpp
@@ -1,63 +1,13 @@
+#include <CLI/Validators.hpp>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
 
-#include "besm-666/sim/hooks.hpp"
-#include "capstone/capstone.h"
-
 #include "CLI/CLI.hpp"
+
 #include "besm-666/exec/gprf.hpp"
 #include "besm-666/sim/config.hpp"
 #include "besm-666/sim/machine.hpp"
-
-csh CapstoneHandler;
-
-void InitVerboseLogging(besm::sim::Machine &machine) {
-    besm::sim::HookManager::SPtr hookManager = machine.getHookManager();
-
-    cs_open(CS_ARCH_RISCV, CS_MODE_RISCV64, &CapstoneHandler);
-    std::atexit([]() {
-        std::clog << "[BESM-666] VERBOSE: Verbose logger finished" << std::endl;
-        cs_close(&CapstoneHandler);
-    });
-
-    std::clog << "[BESM-666] VERBOSE: Verbose logging enabled" << std::endl;
-
-    hookManager->registerHook(
-        besm::sim::HookManager::INSTRUCTION_FETCH,
-        [](besm::sim::Hart const &hart, void const *pBytecode) {
-            besm::RV64UDWord pc = hart.getState().read(besm::exec::GPRF::PC);
-            besm::RV64UWord bytecode =
-                *reinterpret_cast<besm::RV64UWord const *>(pBytecode);
-            std::clog << "[BESM-666] VERBOSE: Fetched bytecode " << std::hex
-                      << bytecode << std::dec << " at pc = " << std::hex << pc
-                      << std::dec << std::endl;
-
-            cs_insn *instruction;
-            size_t count = cs_disasm(
-                CapstoneHandler, reinterpret_cast<uint8_t const *>(pBytecode),
-                4, hart.getState().read(besm::exec::GPRF::PC), 0, &instruction);
-
-            if (count > 0) {
-                std::clog << "[BESM-666] VERBOSE: Disassembly\n\t"
-                          << instruction->mnemonic << " " << instruction->op_str
-                          << std::endl;
-            } else {
-                std::clog << "[BESM-666] VERBOSE: Failed to disasm bytecode"
-                          << std::endl;
-            }
-
-            cs_free(instruction, count);
-        });
-
-    hookManager->registerHook(
-        besm::sim::HookManager::INSTRUCTION_EXECUTE,
-        [](besm::sim::Hart const &hart, void const *) {
-            std::clog << "[BESM-666] VERBOSE: Force dumping machine state."
-                      << std::endl;
-            besm::exec::GPRFStateDumper(std::clog).dump(hart.getState());
-        });
-}
 
 int main(int argc, char *argv[]) {
     besm::sim::ConfigBuilder configBuilder;
@@ -74,21 +24,17 @@ int main(int argc, char *argv[]) {
         ->required()
         ->check(CLI::ExistingFile);
 
-    bool verboseLogging = false;
-    app.add_flag("-v,--verbose", verboseLogging,
-                 "Enables per-instruction machine state logging")
-        ->default_val(false);
+    app.add_option_function<std::string>("-p,--plugin",
+        [&](std::string const& string) {
+            configBuilder.addPlugin(string);
+        },
+        "Use plugin with specified path during the simulation");
 
     CLI11_PARSE(app, argc, argv);
 
     besm::sim::Config config = configBuilder.build();
     besm::sim::Machine machine(config);
     std::clog << "[BESM-666] INFO: Created RISCV machine." << std::endl;
-
-    if (verboseLogging) {
-        InitVerboseLogging(machine);
-    }
-
     std::clog << "[BESM-666] INFO: Starting simulation" << std::endl;
 
     auto time_start = std::chrono::steady_clock::now();


### PR DESCRIPTION
Adds 
- `DynamicLibrary` class that is a simple wrapper class over the linux SO loading interface
- `Plugin` class that holds state of the BESM plugin
- Support of plugin loading by the `Machine` & `HookManager` classes
- Two new events `SIMULATION_STARTED` & `SIMULATION_FINISHED` to hook manager

Moves all tracing functional from standalone runner to `DebugTracer` plugin placed at `plugins/debug_tracer`