### PR TITLE
Added sret and mret instructions to decoder

### DIFF
--- a/include/besm-666/rv-instruction-op.hpp
+++ b/include/besm-666/rv-instruction-op.hpp
@@ -69,7 +69,8 @@ enum InstructionOp {
     CSRRWI, // 1110011 , 101     , I
     CSRRSI, // 1110011 , 110     , I
     CSRRCI, // 1110011 , 111     , I
-
+    SRET,
+    MRET
 };
 
 }

--- a/src/decoder/decoder.cpp
+++ b/src/decoder/decoder.cpp
@@ -161,6 +161,12 @@ Instruction dec::Decoder::parse_I(const RV64UWord bytecode,
             case 0b1:
                 operation = EBREAK;
                 break;
+            case 0b000100000010:
+                operation = SRET;
+                break;
+            case 0b001100000010:
+                operation = MRET;
+                break;
             }
         }
         break;

--- a/unit_test/decoder/decoder_test.cpp
+++ b/unit_test/decoder/decoder_test.cpp
@@ -543,10 +543,31 @@ TEST_F(Decoder_I, EBREAK) {
     EXPECT_TRUE(equal(parsed, instance));
 }
 
+TEST_F(Decoder_I, SRET) {
+    const auto instance = buildInstr(0b0, 0b0, 0b100000010, SRET);
+    Instruction parsed = decoder.parse(0b00010000001000000000000001110011);
+    EXPECT_EQ(parsed.operation, instance.operation);
+    EXPECT_EQ(parsed.immidiate, instance.immidiate);
+    EXPECT_TRUE(equal(parsed, instance));
+}
+
+TEST_F(Decoder_I, MRET) {
+    const auto instance = buildInstr(0b0, 0b0, 0b1100000010, MRET);
+    Instruction parsed = decoder.parse(0b00110000001000000000000001110011);
+    EXPECT_EQ(parsed.operation, instance.operation);
+    EXPECT_EQ(parsed.immidiate, instance.immidiate);
+    EXPECT_TRUE(equal(parsed, instance));
+}
+
 TEST_F(Decoder_I, NOT_EACALL_AND_EBREAK) {
     const auto instance = buildInstr(0b0, 0b0, 0b1, EBREAK);
     Instruction parsed = decoder.parse(0b100001000000001110011);
     EXPECT_FALSE(equal(parsed, instance));
+}
+
+TEST_F(Decoder_I, NOT_SRET_AND_MRET) {
+    Instruction parsed = decoder.parse(0b01110000001000000000000001110011);
+    EXPECT_EQ(parsed.operation, INV_OP);
 }
 
 TEST_F(Decoder_I, LWU1) {


### PR DESCRIPTION
Added `SRET`  and `MRET` according to https://drive.google.com/file/d/1EMip5dZlnypTk7pt4WWUKmtjUKTOkBqh/view , page 138 from https://riscv.org/technical/specifications/